### PR TITLE
Add early exit functionality bitcoin-dlc-provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@
 
 lerna-debug.log
 .vscode
+yarn-error.log

--- a/packages/bitcoin-dlc-provider/lib/BitcoinDlcProvider.ts
+++ b/packages/bitcoin-dlc-provider/lib/BitcoinDlcProvider.ts
@@ -39,7 +39,8 @@ import DlcParty from './models/DlcParty';
 import Contract from './models/Contract';
 
 import Amount from './models/Amount'
-import Input from './models/Input';     
+import Input from './models/Input';
+import Output from './models/Output';
 import InputDetails from './models/InputDetails';
 import PayoutDetails from './models/PayoutDetails';
 import OracleInfo from './models/OracleInfo';
@@ -49,6 +50,7 @@ import SignMessage from './models/SignMessage';
 import Payout from './models/Payout'
 import Utxo from './models/Utxo';
 import { v4 as uuidv4 } from 'uuid';
+import { MutualClosingMessage } from '.';
 
 export default class BitcoinDlcProvider extends Provider {
   _network: any;
@@ -239,7 +241,7 @@ export default class BitcoinDlcProvider extends Provider {
     }
   }
 
-  outputsToPayouts(outputs: Output[], rValuesMessagesList: Messages[], localCollateral: Amount, remoteCollateral: Amount, payoutLocal: boolean): { payouts: PayoutDetails[], messagesList: Messages[] } {
+  outputsToPayouts(outputs: GeneratedOutput[], rValuesMessagesList: Messages[], localCollateral: Amount, remoteCollateral: Amount, payoutLocal: boolean): { payouts: PayoutDetails[], messagesList: Messages[] } {
     const payouts: PayoutDetails[] = []
     const messagesList: Messages[] =[]
 
@@ -313,6 +315,14 @@ export default class BitcoinDlcProvider extends Provider {
 
   async refund(contractId: string) {
     return this.findDlc(contractId).Refund();
+  }
+
+  async initiateEarlyExit(contractId: string, outputs: Output[]) {
+    return this.findDlc(contractId).InitiateEarlyExit(outputs);
+  }
+
+  async finalizeEarlyExit(contractId: string, mutualClosingMessage: MutualClosingMessage) {
+    return this.findDlc(contractId).OnMutualClose(mutualClosingMessage);
   }
 
   async unilateralClose(
@@ -479,7 +489,7 @@ export default class BitcoinDlcProvider extends Provider {
   }
 }
 
-interface Output {
+interface GeneratedOutput {
   payout: number,
   groups: number[][]
 }

--- a/packages/bitcoin-dlc-provider/lib/models/MutualClosingMessage.ts
+++ b/packages/bitcoin-dlc-provider/lib/models/MutualClosingMessage.ts
@@ -1,5 +1,5 @@
-import Outcome from './Outcome';
+import Output from './Output';
 
 export default class MutualClosingMessage {
-  constructor(readonly outcome: Outcome, readonly signature: string) {}
+  constructor(readonly outputs: Output[], readonly signature: string) {}
 }

--- a/packages/bitcoin-dlc-provider/lib/models/Output.ts
+++ b/packages/bitcoin-dlc-provider/lib/models/Output.ts
@@ -1,0 +1,8 @@
+import Amount from './Amount';
+
+export default class Output {
+  constructor(
+    readonly address: string,
+    readonly amount: Amount
+  ) {}
+}

--- a/packages/client/lib/@types/@atomicfinance/bitcoin-dlc-provider/index.d.ts
+++ b/packages/client/lib/@types/@atomicfinance/bitcoin-dlc-provider/index.d.ts
@@ -159,6 +159,18 @@ export class SignMessage {
   constructor(contractId: string, fundTxSignatures: string[], cetSignatures: string[], refundSignature: string, utxoPublicKeys: string[]);
 }
 
+export class Output {
+  readonly address: string;
+  readonly amount: Amount;
+  constructor(address: string, amount: Amount)
+}
+
+export class MutualClosingMessage {
+  readonly outputs: Output[];
+  readonly signature: string;
+  constructor(outputs: Output[], signature: string)
+}
+
 export class Contract {
   id: string;
   localCollateral: Amount;

--- a/packages/client/lib/Dlc.ts
+++ b/packages/client/lib/Dlc.ts
@@ -39,12 +39,14 @@ import {
   Amount,
   Input,
   InputDetails,
+  Output,
   OracleInfo,
   OfferMessage,
   AcceptMessage,
   SignMessage,
   Contract,
-  PayoutDetails
+  PayoutDetails,
+  MutualClosingMessage
 } from './@types/@atomicfinance/bitcoin-dlc-provider';
 
 export default class Dlc {
@@ -94,6 +96,14 @@ export default class Dlc {
 
   async refund(contractId: string) {
     return this.client.getMethod('refund')(contractId);
+  }
+
+  async initiateEarlyExit(contractId: string, outputs: Output[]) {
+    return this.client.getMethod('initiateEarlyExit')(contractId, outputs)
+  }
+
+  async finalizeEarlyExit(contractId: string, mutualClosingMessage: MutualClosingMessage) {
+    return this.client.getMethod('finalizeEarlyExit')(contractId, mutualClosingMessage)
   }
 
   async unilateralClose(
@@ -164,7 +174,7 @@ export default class Dlc {
     return this.client.getMethod('importContractFromSignMessageAndCreateFinal')(offerMessage, acceptMessage, signMessage, startingIndex)
   }
 
-  outputsToPayouts(outputs: Output[], oracleInfos: OracleInfo[], rValuesMessagesList: Messages[], localCollateral: Amount, remoteCollateral: Amount, payoutLocal: boolean): { payouts: PayoutDetails[], messagesList: Messages[] } {
+  outputsToPayouts(outputs: GeneratedOutput[], oracleInfos: OracleInfo[], rValuesMessagesList: Messages[], localCollateral: Amount, remoteCollateral: Amount, payoutLocal: boolean): { payouts: PayoutDetails[], messagesList: Messages[] } {
     return this.client.getMethod('outputsToPayouts')(outputs, oracleInfos, rValuesMessagesList, localCollateral, remoteCollateral, payoutLocal)
   }
 
@@ -263,7 +273,7 @@ export default class Dlc {
   }
 }
 
-interface Output {
+interface GeneratedOutput {
   payout: number,
   groups: number[][]
 }

--- a/tests/integration/common.ts
+++ b/tests/integration/common.ts
@@ -22,7 +22,7 @@ chai.use(chaiAsPromised)
 
 const CONSTANTS = {
   BITCOIN_FEE_PER_BYTE: 3,
-  BITCOIN_ADDRESS_DEFAULT_BALANCE: 50 * 1e8
+  BITCOIN_ADDRESS_DEFAULT_BALANCE: 2 * 1e8
 }
 
 const { network, rpc} = config.bitcoin


### PR DESCRIPTION
A DLC is simply a 2-of-2 multisig with additional off-chain data for exiting with oracle signature or refund.

If participants wish to exit early, they can create a mutual close transaction.

This PR:
- Adds initiateEarlyExit and finalizeEarlyExit to BitcoinDlcProvider to allow parties to generate MutualClosingMessage offer and pass to counterparty, who then can sign and broadcast
- Adds multisig tests which tests the functionality of both initiateEarlyExit and finalizeEarlyExit