### PR TITLE
Remove unnecessary sweep privkey

### DIFF
--- a/packages/bitcoin-dlc-provider/lib/models/DlcParty.ts
+++ b/packages/bitcoin-dlc-provider/lib/models/DlcParty.ts
@@ -48,7 +48,6 @@ export default class DlcParty {
 
   partyInputs: PartyInputs;
   fundPrivateKey: string;
-  sweepPrivateKey: string;
   inputPrivateKeys: string[];
   contract: Contract;
 
@@ -103,15 +102,9 @@ export default class DlcParty {
     const fundPrivateKeyPair = await this.client.getMethod('keyPair')(
       addresses[1].derivationPath
     );
-    const sweepPrivateKeyPair = await this.client.getMethod('keyPair')(
-      changeAddresses[1].derivationPath
-    );
 
     this.fundPrivateKey = Buffer.from(fundPrivateKeyPair.__D).toString('hex');
-    this.sweepPrivateKey = Buffer.from(sweepPrivateKeyPair.__D).toString('hex');
-
     const fundPublicKey = addresses[1].publicKey.toString('hex');
-    const sweepPublicKey = changeAddresses[1].publicKey.toString('hex');
 
     let fundTxCreated = false
     if (this.contract.fundTxHex) {
@@ -141,7 +134,6 @@ export default class DlcParty {
 
     const inputs = new PartyInputs(
       fundPublicKey,
-      sweepPublicKey,
       changeAddress,
       finalAddress,
       utxos

--- a/packages/bitcoin-dlc-provider/lib/models/PartyInputs.ts
+++ b/packages/bitcoin-dlc-provider/lib/models/PartyInputs.ts
@@ -3,7 +3,6 @@ import Utxo, { UtxoJSON } from './Utxo';
 export default class PartyInputs {
   constructor(
     readonly fundPublicKey: string,
-    readonly sweepPublicKey: string,
     readonly changeAddress: string,
     readonly finalAddress: string,
     readonly utxos: Utxo[]
@@ -25,7 +24,6 @@ export default class PartyInputs {
 
     return Object.assign({}, this, {
       fundPublicKey: this.fundPublicKey,
-      sweepPublicKey: this.sweepPublicKey,
       changeAddress: this.changeAddress,
       finalAddress: this.finalAddress,
       utxos: utxosJSON,
@@ -45,7 +43,6 @@ export default class PartyInputs {
 
     return Object.assign(partyInputs, json, {
       fundPublicKey: json.fundPublicKey,
-      sweepPublicKey: json.sweepPublicKey,
       changeAddress: json.changeAddress,
       finalAddress: json.finalAddress,
       utxos,
@@ -59,7 +56,6 @@ export default class PartyInputs {
 
 export interface PartyInputsJSON {
   fundPublicKey: string;
-  sweepPublicKey: string;
   changeAddress: string;
   finalAddress: string;
   utxos: UtxoJSON[];


### PR DESCRIPTION
Since DLC adaptor version, sweep privkeys have been unnecessary since CETs spend directly to payoutSPK