### PR TITLE
Use worker-backed CfdDlcJs for tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@
 /packages/**/lib/models/*.js
 /packages/**/lib/utils/*.js
 
+/file-output/*.txt
+
 lerna-debug.log
 .vscode
 yarn-error.log

--- a/package.json
+++ b/package.json
@@ -5,12 +5,12 @@
     "packages/*"
   ],
   "devDependencies": {
+    "@liquality/bitcoin-esplora-api-provider": "0.10.3",
     "@liquality/bitcoin-js-wallet-provider": "0.10.3",
     "@liquality/bitcoin-networks": "0.10.3",
     "@liquality/bitcoin-node-wallet-provider": "0.10.3",
     "@liquality/bitcoin-rpc-provider": "0.10.3",
     "@liquality/bitcoin-utils": "0.10.3",
-    "@liquality/bitcoin-esplora-api-provider": "0.10.3",
     "@liquality/client": "^0.10.3",
     "@liquality/crypto": "0.10.3",
     "@liquality/errors": "0.10.3",
@@ -37,6 +37,7 @@
     "lodash": "^4.17.20",
     "mocha": "^8.1.3",
     "mocha-webpack": "^1.1.0",
+    "node-worker-threads-pool": "^1.4.3",
     "nyc": "^15.1.0",
     "prettier": "2.2.1",
     "ts-loader": "^8.0.3",
@@ -46,7 +47,8 @@
     "typescript": "4.1.3",
     "wasm-loader": "^1.3.0",
     "webpack": "^4.44.1",
-    "webpack-cli": "^3.3.12"
+    "webpack-cli": "^3.3.12",
+    "fs": "0.0.1-security"
   },
   "scripts": {
     "bootstrap": "lerna bootstrap --force-local && lerna link --force-local",
@@ -55,7 +57,7 @@
     "lint": "lerna run lint",
     "lint:fix": "lerna run lint:fix",
     "build": "lerna run build",
-    "test": "cross-env NODE_ENV=test ts-mocha -p tsconfig.spec.json --timeout 150000 tests/**/*.test.ts",
+    "test": "cross-env NODE_ENV=test ts-mocha -p tsconfig.spec.json --exit --timeout 150000 tests/**/*.test.ts",
     "new:version": "lerna version --no-push --no-git-tag-version && lerna clean --yes && lerna bootstrap",
     "publish:all": "lerna publish from-package",
     "prepublishOnly": "npm run build"

--- a/tests/integration/common.ts
+++ b/tests/integration/common.ts
@@ -14,7 +14,9 @@ import BitcoinWalletProvider from '../../packages/bitcoin-wallet-provider/lib';
 import { generateMnemonic } from 'bip39';
 import config from './config';
 import * as cfdJs from 'cfd-js';
-import * as cfdDlcJs from 'cfd-dlc-js';
+import { getWrappedCfdDlcJs } from './utils/WrappedCfdDlcJs';
+
+const cfdDlcJs = getWrappedCfdDlcJs();
 
 const sleep = utils.sleep;
 

--- a/tests/integration/dlc/dlc.test.ts
+++ b/tests/integration/dlc/dlc.test.ts
@@ -33,6 +33,8 @@ import {
 } from '@node-dlc/messaging';
 import { CoveredCall, groupByIgnoringDigits } from '@node-dlc/core';
 import { sha256 } from '@liquality/crypto';
+import * as fs from 'fs';
+import * as base64 from 'base64-js';
 
 import * as base2Output from '../outputs/base2.json';
 
@@ -227,10 +229,33 @@ describe('tlv integration', () => {
       [aliceInput],
     );
 
-    const acceptMessage = await bob.finance.dlc.confirmContractOffer(
-      offerMessage,
-      [bobInput],
+    console.timeEnd('offer-get-time');
+
+    console.time('accept-time');
+    const {
+      dlcAccept,
+    } = await bob.finance.dlc.confirmContractOffer(offerMessage, [bobInput]);
+    console.time('accept-time-serialize');
+
+    fs.writeFile(
+      'file-output/accept-hex.txt',
+      dlcAccept.serialize().toString('hex'),
+      function (err) {
+        if (err) return console.log(err);
+        console.log('DlcAccept > accept-hex.txt');
+      },
     );
+
+    fs.writeFile(
+      'file-output/accept-base64.txt',
+      base64.fromByteArray(dlcAccept.serialize()),
+      function (err) {
+        if (err) return console.log(err);
+        console.log('DlcAccept > accept-base64.txt');
+      },
+    );
+
+    console.timeEnd('accept-time-serialize');
 
     // generate payouts (used for accept)
     const payouts = CoveredCall.computePayouts(
@@ -254,6 +279,7 @@ describe('tlv integration', () => {
         0,
       )}`,
     );
+    console.timeEnd('accept-time');
   });
 });
 

--- a/tests/integration/utils/WrappedCfdDlcJs.ts
+++ b/tests/integration/utils/WrappedCfdDlcJs.ts
@@ -1,0 +1,35 @@
+import { StaticPool } from 'node-worker-threads-pool';
+import cfdDlcJs from 'cfd-dlc-js';
+
+const FILE_PATH = './tests/integration/utils/cfdDlcJsWorker.js';
+
+const pool = new StaticPool({
+  size: 4,
+  task: FILE_PATH,
+});
+
+const METHODS_TO_PARALLELIZE = [
+  'VerifyCetAdaptorSignatures',
+  'CreateCetAdaptorSignatures',
+];
+
+type CfdDlcJs = typeof cfdDlcJs;
+
+export function getWrappedCfdDlcJs(): CfdDlcJs {
+  const wrappedCfdDlcJs = new Proxy(
+    {},
+    {
+      get: function (_, method) {
+        if (METHODS_TO_PARALLELIZE.indexOf(method as string) !== -1) {
+          return async (...args) => {
+            const res = await pool.exec({ method, args });
+            return res;
+          };
+        }
+        return cfdDlcJs[method];
+      },
+    },
+  );
+
+  return wrappedCfdDlcJs as CfdDlcJs;
+}

--- a/tests/integration/utils/cfdDlcJsWorker.js
+++ b/tests/integration/utils/cfdDlcJsWorker.js
@@ -1,0 +1,8 @@
+const { parentPort } = require('worker_threads');
+const cfdDlcJs = require('cfd-dlc-js');
+
+parentPort.on('message', async (message) => {
+  const { method, args } = message;
+
+  return parentPort.postMessage(cfdDlcJs[method](...args));
+});


### PR DESCRIPTION
Reduces time to create 8k+ CET adaptor signatures from ~8s → ~2s