### PR TITLE
Add inputToFundingInput to dlc client interface

### DIFF
--- a/packages/bitcoin-dlc-provider/lib/BitcoinDlcProvider.ts
+++ b/packages/bitcoin-dlc-provider/lib/BitcoinDlcProvider.ts
@@ -880,6 +880,7 @@ Payout Group not found',
       case MessageType.ContractInfoV0:
         // eslint-disable-next-line no-case-declarations
         const contractInfo = dlcOffer.contractInfo as ContractInfoV0;
+        // eslint-disable-next-line no-case-declarations
         switch (contractInfo.contractDescriptor.type) {
           case MessageType.ContractDescriptorV0:
             throw Error('ContractDescriptorV0 not yet supported');

--- a/packages/client/lib/Dlc.ts
+++ b/packages/client/lib/Dlc.ts
@@ -39,6 +39,7 @@ import {
   DlcSign,
   DlcTransactions,
   OracleAttestationV0,
+  FundingInput,
 } from '@node-dlc/messaging';
 import { Psbt } from 'bitcoinjs-lib';
 import { Tx } from '@node-lightning/bitcoin';
@@ -309,6 +310,14 @@ export default class Dlc {
   ): Promise<VerifyRefundTxSignatureResponse> {
     return this.client.getMethod('VerifyRefundTxSignature')(jsonObject);
   }
+
+  async fundingInputToInput(_input: FundingInput): Promise<IInput> {
+    return this.client.getMethod('fundingInputToInput')(_input);
+  }
+
+  async inputToFundingInput(input: IInput): Promise<FundingInput> {
+    return this.client.getMethod('inputToFundingInput')(input);
+  }
 }
 
 export interface AcceptDlcOfferResponse {
@@ -337,4 +346,5 @@ export interface IInput {
   spendable?: boolean;
   solvable?: boolean;
   safe?: boolean;
+  toUtxo: any;
 }

--- a/tests/integration/utxos/utxos.test.ts
+++ b/tests/integration/utxos/utxos.test.ts
@@ -21,16 +21,16 @@ describe('utxos', () => {
   describe('inputToFundingInput', () => {
     it('should convert between types', async () => {
       const actualInput: Input = await getInput(alice);
-      const actualFundingInput: FundingInputV0 = await alice.getMethod(
-        'inputToFundingInput',
-      )(actualInput);
+      const actualFundingInput: FundingInputV0 = (await alice.dlc.inputToFundingInput(
+        actualInput,
+      )) as FundingInputV0;
 
-      const input: Input = await alice.getMethod('fundingInputToInput')(
+      const input: Input = await alice.dlc.fundingInputToInput(
         actualFundingInput,
       );
-      const fundingInput: FundingInputV0 = await alice.getMethod(
-        'inputToFundingInput',
-      )(input);
+      const fundingInput: FundingInputV0 = (await alice.dlc.inputToFundingInput(
+        input,
+      )) as FundingInputV0;
 
       expect(actualInput.txid).to.equal(input.txid);
       expect(actualInput.vout).to.equal(input.vout);


### PR DESCRIPTION
This PR adds `inputToFundingInput` and `fundingInputToInput` to DLC Client interface