### PR TITLE
Implement quickFindAddress into BitcoinWalletProvider

### DIFF
--- a/packages/bitcoin-dlc-provider/lib/BitcoinDlcProvider.ts
+++ b/packages/bitcoin-dlc-provider/lib/BitcoinDlcProvider.ts
@@ -1722,12 +1722,9 @@ Payout Group not found',
     let derivationPath: string;
 
     if (findDerivationPath) {
-      let inputAddress: Address = await this.getMethod('findAddress')([
-        _address,
-      ]);
-      if (!inputAddress) {
-        inputAddress = await this.getMethod('findAddress')([_address], true);
-      }
+      const inputAddress: Address = await this.client.financewallet.quickFindAddress(
+        [_address],
+      );
       if (inputAddress) {
         derivationPath = inputAddress.derivationPath;
       }

--- a/packages/bitcoin-wallet-provider/lib/BitcoinWalletProvider.ts
+++ b/packages/bitcoin-wallet-provider/lib/BitcoinWalletProvider.ts
@@ -336,6 +336,33 @@ export default class BitcoinWalletProvider
 
     return { hex: txb.build().toHex(), fee };
   }
+
+  async quickFindAddress(addresses: string[]): Promise<Address> {
+    const maxAddresses = 500;
+    const addressesPerCall = 5;
+    let index = 0;
+    while (index < maxAddresses) {
+      const walletNonChangeAddresses = await this.getMethod('getAddresses')(
+        index,
+        addressesPerCall,
+        true,
+      );
+      const walletChangeAddresses = await this.getMethod('getAddresses')(
+        index,
+        addressesPerCall,
+        false,
+      );
+      const walletAddresses = [
+        ...walletNonChangeAddresses,
+        ...walletChangeAddresses,
+      ];
+      const walletAddress = walletAddresses.find((walletAddr) =>
+        addresses.find((addr) => walletAddr.address === addr),
+      );
+      if (walletAddress) return walletAddress;
+      index += addressesPerCall;
+    }
+  }
 }
 
 interface Output {

--- a/packages/client/lib/Wallet.ts
+++ b/packages/client/lib/Wallet.ts
@@ -38,4 +38,8 @@ export default class Wallet {
   async getUnusedAddress(change = false, numAddressPerCall = 100) {
     return this.client.getMethod('getUnusedAddress')(change, numAddressPerCall);
   }
+
+  async quickFindAddress(addresses: string[]) {
+    return this.client.getMethod('quickFindAddress')(addresses);
+  }
 }

--- a/packages/types/lib/financewallet.ts
+++ b/packages/types/lib/financewallet.ts
@@ -1,3 +1,4 @@
+import { Address } from '@liquality/types';
 import Input from './models/Input';
 
 export interface FinanceWalletProvider {
@@ -20,6 +21,8 @@ export interface FinanceWalletProvider {
     _outputs: Output[],
     fixedInputs: Input[],
   );
+
+  quickFindAddress(addresses: string[]);
 }
 
 interface Output {

--- a/tests/integration/wallet/wallet.test.ts
+++ b/tests/integration/wallet/wallet.test.ts
@@ -80,4 +80,34 @@ describe.skip('wallet provider', () => {
       expect(carolAddresses[1]).to.deep.equal(daveUnusedAddress);
     });
   });
+
+  describe('quickFindAddress', () => {
+    it('should find change or non change addresses', async () => {
+      const firstThirtyNonChangeAddresses = await alice.wallet.getAddresses(
+        0,
+        30,
+        false,
+      );
+      const firstThirtyChangeAddresses = await alice.wallet.getAddresses(
+        0,
+        30,
+        true,
+      );
+      const nonChangeAddress =
+        firstThirtyNonChangeAddresses[firstThirtyNonChangeAddresses.length - 1];
+      const changeAddress =
+        firstThirtyChangeAddresses[firstThirtyChangeAddresses.length - 1];
+
+      const foundNonChangeAddress = await alice.financewallet.quickFindAddress([
+        nonChangeAddress.address,
+      ]);
+
+      const foundChangeAddress = await alice.financewallet.quickFindAddress([
+        changeAddress.address,
+      ]);
+
+      expect(nonChangeAddress.address).to.equal(foundNonChangeAddress.address);
+      expect(changeAddress.address).to.equal(foundChangeAddress.address);
+    });
+  });
 });


### PR DESCRIPTION
This PR implements `quickFindAddress` into `BitcoinWalletProvider`

This works by deriving the first 5 change and non-change addresses and checking if they match any of the addresses provided, continuing in a loop until an address is found. 

It is an improvement on `findAddress` which requires you to specify change or non-change address. 