### PR TITLE
Add event validation for execute in BitcoinDlcProvider

### DIFF
--- a/packages/bitcoin-dlc-provider/lib/BitcoinDlcProvider.ts
+++ b/packages/bitcoin-dlc-provider/lib/BitcoinDlcProvider.ts
@@ -901,6 +901,41 @@ Payout Group not found',
     }
   }
 
+  ValidateEvent(
+    _dlcOffer: DlcOffer,
+    oracleAttestation: OracleAttestationV0,
+  ): void {
+    const { dlcOffer } = checkTypes({
+      _dlcOffer,
+    });
+
+    switch (dlcOffer.contractInfo.type) {
+      case MessageType.ContractInfoV0:
+        // eslint-disable-next-line no-case-declarations
+        const contractInfo = dlcOffer.contractInfo as ContractInfoV0;
+        switch (contractInfo.contractDescriptor.type) {
+          case MessageType.ContractDescriptorV0:
+            throw Error('ContractDescriptorV0 not yet supported');
+          case MessageType.ContractDescriptorV1:
+            // eslint-disable-next-line no-case-declarations
+            const oracleInfo = contractInfo.oracleInfo;
+            if (
+              oracleInfo.announcement.oracleEvent.eventId !==
+              oracleAttestation.eventId
+            )
+              throw Error('Incorrect Oracle Attestation. Event Id must match.');
+            break;
+          default:
+            throw Error('ConractDescriptor must be V0 or V1');
+        }
+        break;
+      case MessageType.ContractInfoV1:
+        throw Error('MultiOracle not yet supported');
+      default:
+        throw Error('ContractInfo must be V0 or V1');
+    }
+  }
+
   async FindAndSignCet(
     _dlcOffer: DlcOffer,
     _dlcAccept: DlcAccept,
@@ -1447,6 +1482,8 @@ Payout Group not found',
       _dlcSign,
       _dlcTxs,
     });
+
+    this.ValidateEvent(dlcOffer, oracleAttestation);
 
     return this.FindAndSignCet(
       dlcOffer,

--- a/tests/integration/dlc/dlc.test.ts
+++ b/tests/integration/dlc/dlc.test.ts
@@ -161,6 +161,25 @@ describe('dlc provider', () => {
       expect(cetTx._raw.vin.length).to.equal(1);
     });
 
+    it(`should fail to execute if event id's don't match`, async () => {
+      oracleAttestation.eventId = 'invalidId';
+
+      let error = null;
+      try {
+        await bob.dlc.execute(
+          dlcOffer,
+          dlcAccept,
+          dlcSign,
+          dlcTransactions,
+          oracleAttestation,
+          false,
+        );
+      } catch (e) {
+        error = e;
+      }
+      expect(error).to.be.an('Error');
+    });
+
     it('refund', async () => {
       const refund = await bob.dlc.refund(
         dlcOffer,


### PR DESCRIPTION
This PR adds event validation for execute in `BitcoinDlcProvider`

This ensures that a transaction is not executed with an incorrect attestation