### PR TITLE
Fix outcome index finding

### DIFF
--- a/packages/bitcoin-dlc-provider/lib/BitcoinDlcProvider.ts
+++ b/packages/bitcoin-dlc-provider/lib/BitcoinDlcProvider.ts
@@ -785,12 +785,12 @@ export default class BitcoinDlcProvider
 
     const { payoutGroups } = this.GetPayouts(dlcOffer);
 
-    const intervalsSorted = contractDescriptor.roundingIntervals.intervals.sort(
+    const intervalsSorted = [...contractDescriptor.roundingIntervals.intervals].sort(
       (a, b) => Number(b.beginInterval) - Number(a.beginInterval),
     );
 
     const interval = intervalsSorted.find(
-      (interval) => payout.toNumber() > Number(interval.beginInterval),
+      (interval) => Number(outcome) > Number(interval.beginInterval),
     );
 
     const roundedPayout = BigInt(

--- a/tests/integration/dlc/dlc.test.ts
+++ b/tests/integration/dlc/dlc.test.ts
@@ -245,7 +245,10 @@ describe('dlc provider', () => {
         numDigits,
       );
 
-      const intervals = [{ beginInterval: 0n, roundingMod: 500n }];
+      const intervals = [
+        { beginInterval: 0n, roundingMod: 1n },
+        { beginInterval: 4000n, roundingMod: 500n },
+      ];
       const roundingIntervals = new RoundingIntervalsV0();
       roundingIntervals.intervals = intervals;
 
@@ -372,7 +375,10 @@ describe('external test vectors', () => {
       numDigits,
     );
 
-    const intervals = [{ beginInterval: 0n, roundingMod: 50000n }];
+    const intervals = [
+      { beginInterval: 0n, roundingMod: 1n },
+      { beginInterval: 60000n, roundingMod: 50000n },
+    ];
     const roundingIntervals = new RoundingIntervalsV0();
     roundingIntervals.intervals = intervals;
 


### PR DESCRIPTION
* Fix modifying the actual intervals array in the contract descriptor (.sort modifies array in-place)
* Fix rounding interval lookup (should be looking up based on outcome, not on payout)