### PR TITLE
Update for Serial Id Input and Output ordering

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "bignumber.js": "^9.0.1",
     "bip-schnorr": "^0.6.2",
     "bip39": "^3.0.2",
-    "cfd-dlc-js": "https://github.com/atomicfinance/cfd-dlc-js.git#v0.0.18",
+    "cfd-dlc-js": "https://github.com/atomicfinance/cfd-dlc-js.git#v0.0.25",
     "cfd-js": "https://github.com/cryptogarageinc/cfd-js.git#v0.3.3",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",

--- a/packages/bitcoin-dlc-provider/lib/BitcoinDlcProvider.ts
+++ b/packages/bitcoin-dlc-provider/lib/BitcoinDlcProvider.ts
@@ -94,7 +94,6 @@ import {
 } from './utils/Utils';
 
 const ESTIMATED_SIZE = 312;
-const TEMP_FORCE_SERIAL_ID_ORDERING = true;
 
 export default class BitcoinDlcProvider
   extends Provider
@@ -415,9 +414,7 @@ export default class BitcoinDlcProvider
       remoteChangeScriptPubkey,
       feeRate: Number(dlcOffer.feeRatePerVb),
       cetLockTime: dlcOffer.cetLocktime,
-      fundOutputSerialId: TEMP_FORCE_SERIAL_ID_ORDERING
-        ? BigInt(Number(dlcOffer.changeSerialId) - 1)
-        : dlcOffer.fundOutputSerialId, // TODO SERIAL_ID remove temp force serial id ordering
+      fundOutputSerialId: dlcOffer.fundOutputSerialId,
     };
 
     const dlcTxs = await this.CreateDlcTransactions(dlcTxRequest);
@@ -1407,9 +1404,7 @@ Payout Group not found',
     dlcOffer.fundingInputs = fundingInputs;
     dlcOffer.changeSPK = changeSPK;
     dlcOffer.changeSerialId = changeSerialId;
-    dlcOffer.fundOutputSerialId = TEMP_FORCE_SERIAL_ID_ORDERING
-      ? BigInt(Number(changeSerialId) - 1)
-      : (dlcOffer.fundOutputSerialId = fundOutputSerialId); // TODO SERIAL_ID remove temp force serial id ordering
+    dlcOffer.fundOutputSerialId = dlcOffer.fundOutputSerialId = fundOutputSerialId;
     dlcOffer.feeRatePerVb = feeRatePerVb;
     dlcOffer.cetLocktime = cetLocktime;
     dlcOffer.refundLocktime = refundLocktime;
@@ -1497,14 +1492,10 @@ Payout Group not found',
     dlcAccept.acceptCollateralSatoshis = acceptCollateralSatoshis;
     dlcAccept.fundingPubKey = fundingPubKey;
     dlcAccept.payoutSPK = payoutSPK;
-    dlcAccept.payoutSerialId = TEMP_FORCE_SERIAL_ID_ORDERING
-      ? BigInt(Number(dlcOffer.payoutSerialId) + 1)
-      : (dlcAccept.payoutSerialId = payoutSerialId); // TODO SERIAL_ID remove temp force serial id ordering
+    dlcAccept.payoutSerialId = dlcAccept.payoutSerialId = payoutSerialId;
     dlcAccept.fundingInputs = fundingInputs;
     dlcAccept.changeSPK = changeSPK;
-    dlcAccept.changeSerialId = TEMP_FORCE_SERIAL_ID_ORDERING
-      ? BigInt(Number(dlcOffer.changeSerialId) + 1)
-      : (dlcAccept.changeSerialId = changeSerialId); // TODO SERIAL_ID remove temp force serial id ordering
+    dlcAccept.changeSerialId = dlcAccept.changeSerialId = changeSerialId;
 
     assert(
       dlcAccept.changeSerialId !== dlcOffer.fundOutputSerialId,

--- a/packages/types/lib/dlc.ts
+++ b/packages/types/lib/dlc.ts
@@ -259,6 +259,9 @@ interface FindOutcomeResponse {
   groupLength: number;
 }
 
+/* eslint-disable max-len */
+/* eslint-disable indent */
+
 export interface AdaptorPair {
   signature: string;
   proof: string;
@@ -289,18 +292,6 @@ export interface AddSignatureToFundTransactionRequest {
 
 export interface AddSignatureToFundTransactionResponse {
   hex: string;
-}
-
-/** Create an adaptor signature using multiple oracles for a CET */
-export interface CreateCetAdaptorSignatureMultiOracleRequest {
-  cetHex: string;
-  privkey: string;
-  fundTxId: string;
-  fundVout?: number;
-  localFundPubkey: string;
-  remoteFundPubkey: string;
-  oracleInfos: OracleInfo[];
-  fundInputAmount: bigint | number;
 }
 
 /** Create an adaptor signature for a CET */
@@ -351,6 +342,8 @@ export interface CreateCetRequest {
   fundTxId: string;
   fundVout?: number;
   lockTime: bigint | number;
+  localSerialId?: bigint | number;
+  remoteSerialId?: bigint | number;
 }
 
 export interface CreateCetResponse {
@@ -366,8 +359,12 @@ export interface CreateDlcTransactionsRequest {
   remoteFinalScriptPubkey: string;
   localInputAmount: bigint | number;
   localCollateralAmount: bigint | number;
+  localPayoutSerialId: bigint | number;
+  localChangeSerialId: bigint | number;
   remoteInputAmount: bigint | number;
   remoteCollateralAmount: bigint | number;
+  remotePayoutSerialId: bigint | number;
+  remoteChangeSerialId: bigint | number;
   refundLocktime: bigint | number;
   localInputs: TxInInfoRequest[];
   localChangeScriptPubkey: string;
@@ -376,6 +373,7 @@ export interface CreateDlcTransactionsRequest {
   feeRate: number;
   cetLockTime?: bigint | number;
   fundLockTime?: bigint | number;
+  fundOutputSerialId?: bigint | number;
   optionDest?: string;
   optionPremium?: bigint | number;
 }
@@ -391,13 +389,17 @@ export interface CreateFundTransactionRequest {
   localPubkey: string;
   remotePubkey: string;
   outputAmount: bigint | number;
-  localInputs: TxInRequest[];
+  localInputs: TxInInfoRequest[];
   localChange: TxOutRequest;
-  remoteInputs: TxInRequest[];
+  remoteInputs: TxInInfoRequest[];
   remoteChange: TxOutRequest;
   feeRate: bigint | number;
   optionDest?: string;
   optionPremium?: bigint | number;
+  lockTime?: bigint | number;
+  localSerialId?: bigint | number;
+  remoteSerialId?: bigint | number;
+  outputSerialId?: bigint | number;
 }
 
 export interface CreateFundTransactionResponse {
@@ -451,12 +453,6 @@ export interface Messages {
   messages: string[];
 }
 
-export interface OracleInfo {
-  oraclePubkey: string;
-  oracleRValues: string[];
-  messages: string[];
-}
-
 export interface PayoutRequest {
   local: bigint | number;
   remote: bigint | number;
@@ -497,20 +493,7 @@ export interface TxInInfoRequest {
   vout: number;
   redeemScript?: string;
   maxWitnessLength: number;
-}
-
-/** Verify a signature for a CET */
-export interface VerifyCetAdaptorSignatureMultiOracleRequest {
-  cetHex: string;
-  adaptorSignature: string;
-  adaptorProof: string;
-  oracleInfos: OracleInfo[];
-  localFundPubkey: string;
-  remoteFundPubkey: string;
-  fundTxId: string;
-  fundVout?: number;
-  fundInputAmount: bigint | number;
-  verifyRemote: boolean;
+  inputSerialId?: bigint | number;
 }
 
 /** Verify a signature for a CET */

--- a/tests/integration/dlc/dlc.test.ts
+++ b/tests/integration/dlc/dlc.test.ts
@@ -1,3 +1,5 @@
+import 'mocha';
+
 import { BitcoinNetworks } from '@liquality/bitcoin-networks';
 import { CoveredCall, groupByIgnoringDigits } from '@node-dlc/core';
 import {
@@ -22,7 +24,7 @@ import BN from 'bignumber.js';
 import { Psbt } from 'bitcoinjs-lib';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import 'mocha';
+
 import {
   AcceptDlcOfferResponse,
   SignDlcAcceptResponse,


### PR DESCRIPTION
This PR updates CAL Finance to cfd-dlc-js v0.0.25 with to enable serial ids input and output ordering