### PR TITLE
Add verifyBatchDlcClose

### DIFF
--- a/packages/bitcoin-dlc-provider/lib/BitcoinDlcProvider.ts
+++ b/packages/bitcoin-dlc-provider/lib/BitcoinDlcProvider.ts
@@ -2360,7 +2360,7 @@ Payout Group not found',
    * @param _dlcTxs DlcTransactions TLV (V0)
    * @param _dlcCloses DlcClose[] TLV (V0)
    * @param isOfferer Whether offerer or not
-   * @returns {Promise<boolean>}
+   * @returns {Promise<void>}
    */
   async verifyBatchDlcClose(
     _dlcOffer: DlcOffer,
@@ -2368,7 +2368,7 @@ Payout Group not found',
     _dlcTxs: DlcTransactions,
     _dlcCloses: DlcClose[],
     isOfferer?: boolean,
-  ): Promise<boolean> {
+  ): Promise<void> {
     const { dlcOffer, dlcAccept, dlcTxs } = checkTypes({
       _dlcOffer,
       _dlcAccept,
@@ -2407,7 +2407,7 @@ Payout Group not found',
       isOfferer,
     );
 
-    return areSigsValid;
+    assert(areSigsValid, 'Signatures invalid in Verify Batch DlcClose');
   }
 
   /**

--- a/packages/bitcoin-dlc-provider/lib/BitcoinDlcProvider.ts
+++ b/packages/bitcoin-dlc-provider/lib/BitcoinDlcProvider.ts
@@ -42,6 +42,7 @@ import {
   VerifyFundTxSignatureResponse,
   VerifyRefundTxSignatureRequest,
   VerifyRefundTxSignatureResponse,
+  VerifySignatureRequest,
 } from '@atomicfinance/types';
 import { BitcoinNetwork } from '@liquality/bitcoin-networks';
 import { Address, bitcoin } from '@liquality/types';
@@ -1236,10 +1237,11 @@ Payout Group not found',
     _dlcOffer: DlcOffer,
     _dlcAccept: DlcAccept,
     _dlcTxs: DlcTransactions,
-    initiatorPayouts: bigint[],
     closeInputAmount: bigint,
-    fundingInputs: FundingInput[],
     isOfferer: boolean,
+    _dlcCloses: DlcClose[] = [],
+    fundingInputs?: FundingInput[],
+    initiatorPayouts?: bigint[],
   ): Promise<string[]> {
     const { dlcOffer, dlcAccept, dlcTxs } = checkTypes({
       _dlcOffer,
@@ -1248,26 +1250,42 @@ Payout Group not found',
     });
     const network = await this.getConnectedNetwork();
 
-    const finalizer = new DualClosingTxFinalizer(
-      fundingInputs,
-      dlcOffer.payoutSPK,
-      dlcAccept.payoutSPK,
-      dlcOffer.feeRatePerVb,
-    );
+    let finalizer: DualClosingTxFinalizer;
+    if (_dlcCloses.length === 0) {
+      finalizer = new DualClosingTxFinalizer(
+        fundingInputs,
+        dlcOffer.payoutSPK,
+        dlcAccept.payoutSPK,
+        dlcOffer.feeRatePerVb,
+      );
+    }
 
     const rawTransactionRequestPromises: Promise<string>[] = [];
     const rawCloseTxs = [];
 
-    for (let i = 0; i < initiatorPayouts.length; i++) {
-      const payout = initiatorPayouts[i];
+    const numPayouts =
+      _dlcCloses.length === 0 ? initiatorPayouts.length : _dlcCloses.length;
 
-      const offerPayoutValue: bigint = isOfferer
-        ? closeInputAmount + payout - finalizer.offerInitiatorFees
-        : dlcOffer.contractInfo.totalCollateral - payout;
+    for (let i = 0; i < numPayouts; i++) {
+      let offerPayoutValue = BigInt(0);
+      let acceptPayoutValue = BigInt(0);
 
-      const acceptPayoutValue: bigint = isOfferer
-        ? dlcOffer.contractInfo.totalCollateral - payout
-        : closeInputAmount + payout - finalizer.offerInitiatorFees;
+      if (_dlcCloses.length === 0) {
+        const payout = initiatorPayouts[i];
+
+        offerPayoutValue = isOfferer
+          ? closeInputAmount + payout - finalizer.offerInitiatorFees
+          : dlcOffer.contractInfo.totalCollateral - payout;
+
+        acceptPayoutValue = isOfferer
+          ? dlcOffer.contractInfo.totalCollateral - payout
+          : closeInputAmount + payout - finalizer.offerInitiatorFees;
+      } else {
+        const dlcClose = checkTypes({ _dlcClose: _dlcCloses[i] }).dlcClose;
+
+        offerPayoutValue = dlcClose.offerPayoutSatoshis;
+        acceptPayoutValue = dlcClose.acceptPayoutSatoshis;
+      }
 
       const txOuts = [
         {
@@ -1415,6 +1433,79 @@ Payout Group not found',
     const sigs: string[] = await Promise.all(sigsRequestPromises);
 
     return sigs.flat();
+  }
+
+  async VerifySignatures(
+    _dlcOffer: DlcOffer,
+    _dlcAccept: DlcAccept,
+    _dlcTxs: DlcTransactions,
+    _dlcCloses: DlcClose[],
+    rawCloseTxs: string[],
+    isOfferer: boolean,
+  ): Promise<boolean> {
+    const { dlcOffer, dlcAccept, dlcTxs } = checkTypes({
+      _dlcOffer,
+      _dlcAccept,
+      _dlcTxs,
+    });
+
+    const dlcCloses = _dlcCloses.map(
+      (_dlcClose) => checkTypes({ _dlcClose }).dlcClose,
+    );
+
+    const network = await this.getConnectedNetwork();
+
+    const fundingPubKeys =
+      Buffer.compare(dlcOffer.fundingPubKey, dlcAccept.fundingPubKey) === -1
+        ? [dlcOffer.fundingPubKey, dlcAccept.fundingPubKey]
+        : [dlcAccept.fundingPubKey, dlcOffer.fundingPubKey];
+
+    const p2ms = payments.p2ms({
+      m: 2,
+      pubkeys: fundingPubKeys,
+      network,
+    });
+
+    const paymentVariant = payments.p2wsh({
+      redeem: p2ms,
+      network,
+    });
+
+    const pubkey = isOfferer ? dlcAccept.fundingPubKey : dlcOffer.fundingPubKey;
+
+    const sigsValidity: Promise<boolean>[] = [];
+
+    for (let i = 0; i < rawCloseTxs.length; i++) {
+      const rawTx = rawCloseTxs[i];
+      const dlcClose = dlcCloses[i];
+
+      const verifySignatureRequest: VerifySignatureRequest = {
+        tx: rawTx,
+        txin: {
+          txid: dlcTxs.fundTx.txId.serialize().reverse().toString('hex'),
+          vout: dlcTxs.fundTxVout,
+          signature: dlcClose.closeSignature.toString('hex'),
+          pubkey: pubkey.toString('hex'),
+          redeemScript: paymentVariant.redeem.output.toString('hex'),
+          hashType: 'p2wsh',
+          sighashType: 'all',
+          sighashAnyoneCanPay: false,
+          amount: Number(dlcTxs.fundTx.outputs[dlcTxs.fundTxVout].value.sats),
+        },
+      };
+
+      sigsValidity.push(
+        (async () => {
+          const response = await this.getMethod('VerifySignature')(
+            verifySignatureRequest,
+          );
+          return response.success;
+        })(),
+      );
+    }
+
+    const areSigsValid = (await Promise.all(sigsValidity)).every((b) => b);
+    return areSigsValid;
   }
 
   /**
@@ -2215,10 +2306,11 @@ Payout Group not found',
       dlcOffer,
       dlcAccept,
       dlcTxs,
-      initiatorPayouts,
       closeInputAmount,
-      fundingInputs,
       isOfferer,
+      [],
+      fundingInputs,
+      initiatorPayouts,
     );
 
     const sigHashes = await this.CreateSignatureHashes(
@@ -2259,6 +2351,63 @@ Payout Group not found',
     });
 
     return dlcCloses;
+  }
+
+  /**
+   * Verify multiple DlcClose messagetypes for closing DLC with Mutual Consent
+   * @param _dlcOffer DlcOffer TLV (V0)
+   * @param _dlcAccept DlcAccept TLV (V0)
+   * @param _dlcTxs DlcTransactions TLV (V0)
+   * @param _dlcCloses DlcClose[] TLV (V0)
+   * @param isOfferer Whether offerer or not
+   * @returns {Promise<boolean>}
+   */
+  async verifyBatchDlcClose(
+    _dlcOffer: DlcOffer,
+    _dlcAccept: DlcAccept,
+    _dlcTxs: DlcTransactions,
+    _dlcCloses: DlcClose[],
+    isOfferer?: boolean,
+  ): Promise<boolean> {
+    const { dlcOffer, dlcAccept, dlcTxs } = checkTypes({
+      _dlcOffer,
+      _dlcAccept,
+      _dlcTxs,
+    });
+
+    const dlcCloses = _dlcCloses.map(
+      (_dlcClose) => checkTypes({ _dlcClose }).dlcClose,
+    );
+
+    if (isOfferer === undefined)
+      isOfferer = await this.isOfferer(dlcOffer, dlcAccept);
+
+    assert(
+      dlcCloses.every((dlcClose) => dlcClose.fundingInputs.length === 0),
+      'funding inputs not supported on verify BatchDlcClose',
+    ); // TODO support multiple funding inputs
+
+    const closeInputAmount = BigInt(0); // TODO support multiple funding inputs
+
+    const rawCloseTxs = await this.CreateCloseRawTxs(
+      dlcOffer,
+      dlcAccept,
+      dlcTxs,
+      closeInputAmount,
+      isOfferer,
+      dlcCloses,
+    );
+
+    const areSigsValid = await this.VerifySignatures(
+      dlcOffer,
+      dlcAccept,
+      dlcTxs,
+      dlcCloses,
+      rawCloseTxs,
+      isOfferer,
+    );
+
+    return areSigsValid;
   }
 
   /**

--- a/packages/client/lib/Dlc.ts
+++ b/packages/client/lib/Dlc.ts
@@ -244,6 +244,31 @@ export default class Dlc {
   }
 
   /**
+   * Verify multiple DlcClose messagetypes for closing DLC with Mutual Consent
+   * @param dlcOffer DlcOffer TLV (V0)
+   * @param dlcAccept DlcAccept TLV (V0)
+   * @param dlcTxs DlcTransactions TLV (V0)
+   * @param dlcCloses DlcClose[] TLV (V0)
+   * @param isOfferer Whether offerer or not
+   * @returns {Promise<boolean>}
+   */
+  async verifyBatchDlcClose(
+    dlcOffer: DlcOffer,
+    dlcAccept: DlcAccept,
+    dlcTxs: DlcTransactions,
+    dlcCloses: DlcClose[],
+    isOfferer?: boolean,
+  ): Promise<boolean> {
+    return this.client.getMethod('verifyBatchDlcClose')(
+      dlcOffer,
+      dlcAccept,
+      dlcTxs,
+      dlcCloses,
+      isOfferer,
+    );
+  }
+
+  /**
    * Finalize Dlc Close
    * @param dlcOffer Dlc Offer Message
    * @param dlcAccept Dlc Accept Message

--- a/packages/client/lib/Dlc.ts
+++ b/packages/client/lib/Dlc.ts
@@ -250,7 +250,7 @@ export default class Dlc {
    * @param dlcTxs DlcTransactions TLV (V0)
    * @param dlcCloses DlcClose[] TLV (V0)
    * @param isOfferer Whether offerer or not
-   * @returns {Promise<boolean>}
+   * @returns {Promise<void>}
    */
   async verifyBatchDlcClose(
     dlcOffer: DlcOffer,
@@ -258,7 +258,7 @@ export default class Dlc {
     dlcTxs: DlcTransactions,
     dlcCloses: DlcClose[],
     isOfferer?: boolean,
-  ): Promise<boolean> {
+  ): Promise<void> {
     return this.client.getMethod('verifyBatchDlcClose')(
       dlcOffer,
       dlcAccept,

--- a/packages/types/lib/dlc.ts
+++ b/packages/types/lib/dlc.ts
@@ -147,7 +147,7 @@ export interface DlcProvider {
    * @param _dlcTxs DlcTransactions TLV (V0)
    * @param _dlcCloses DlcClose[] TLV (V0)
    * @param isOfferer Whether offerer or not
-   * @returns {Promise<boolean>}
+   * @returns {Promise<void>}
    */
   verifyBatchDlcClose(
     _dlcOffer: DlcOffer,
@@ -155,7 +155,7 @@ export interface DlcProvider {
     _dlcTxs: DlcTransactions,
     _dlcCloses: DlcClose[],
     isOfferer?: boolean,
-  ): Promise<boolean>;
+  ): Promise<void>;
 
   /**
    * Finalize Dlc Close

--- a/packages/types/lib/dlc.ts
+++ b/packages/types/lib/dlc.ts
@@ -141,6 +141,23 @@ export interface DlcProvider {
   ): Promise<DlcClose[]>;
 
   /**
+   * Verify multiple DlcClose messagetypes for closing DLC with Mutual Consent
+   * @param _dlcOffer DlcOffer TLV (V0)
+   * @param _dlcAccept DlcAccept TLV (V0)
+   * @param _dlcTxs DlcTransactions TLV (V0)
+   * @param _dlcCloses DlcClose[] TLV (V0)
+   * @param isOfferer Whether offerer or not
+   * @returns {Promise<boolean>}
+   */
+  verifyBatchDlcClose(
+    _dlcOffer: DlcOffer,
+    _dlcAccept: DlcAccept,
+    _dlcTxs: DlcTransactions,
+    _dlcCloses: DlcClose[],
+    isOfferer?: boolean,
+  ): Promise<boolean>;
+
+  /**
    * Finalize Dlc Close
    * @param _dlcOffer Dlc Offer Message
    * @param _dlcAccept Dlc Accept Message

--- a/tests/integration/dlc/dlc.test.ts
+++ b/tests/integration/dlc/dlc.test.ts
@@ -281,6 +281,17 @@ describe('dlc provider', () => {
           undefined,
         );
 
+        console.time('batch-close-verify');
+        const aliceDlcClosesValid = await bob.dlc.verifyBatchDlcClose(
+          dlcOffer,
+          dlcAccept,
+          dlcTransactions,
+          aliceDlcCloses,
+        );
+        console.timeEnd('batch-close-verify');
+
+        expect(aliceDlcClosesValid).to.equal(true);
+
         const bobDlcTx = await bob.dlc.finalizeDlcClose(
           dlcOffer,
           dlcAccept,
@@ -356,6 +367,26 @@ describe('dlc provider', () => {
             true,
             [wrongInput],
           ),
+        ).to.be.eventually.rejectedWith(Error);
+      });
+
+      it('should fail verify batch close with fixedInputs', async () => {
+        // TODO support multiple funding inputs
+        const aliceInput = await getInput(alice);
+
+        const aliceDlcClose: DlcClose = await alice.dlc.createDlcClose(
+          dlcOffer,
+          dlcAccept,
+          dlcTransactions,
+          10000n,
+          true,
+          [aliceInput],
+        );
+
+        expect(
+          alice.dlc.verifyBatchDlcClose(dlcOffer, dlcAccept, dlcTransactions, [
+            aliceDlcClose,
+          ]),
         ).to.be.eventually.rejectedWith(Error);
       });
 


### PR DESCRIPTION
This PR adds `verifyBatchDlcClose` which allows verification of multiple DlcClose message closing signatures

Note: It does not support multiple funding inputs on these DlcClose messages (and throws and Error if any DlcClose provided contains fundingInputs)