### PR TITLE
Expose createDlcTxs fn

### DIFF
--- a/packages/bitcoin-dlc-provider/lib/BitcoinDlcProvider.ts
+++ b/packages/bitcoin-dlc-provider/lib/BitcoinDlcProvider.ts
@@ -378,7 +378,7 @@ export default class BitcoinDlcProvider
     }
   }
 
-  private async CreateDlcTxs(
+  public async createDlcTxs(
     _dlcOffer: DlcOffer,
     _dlcAccept: DlcAccept,
   ): Promise<CreateDlcTxsResponse> {
@@ -1765,7 +1765,7 @@ Payout Group not found',
       'fundingInputs for dlcAccept must be greater than acceptCollateralSatoshis plus acceptFees',
     );
 
-    const { dlcTransactions, messagesList } = await this.CreateDlcTxs(
+    const { dlcTransactions, messagesList } = await this.createDlcTxs(
       dlcOffer,
       dlcAccept,
     );
@@ -1824,7 +1824,7 @@ Payout Group not found',
 
     const dlcSign = new DlcSignV0();
 
-    const { dlcTransactions, messagesList } = await this.CreateDlcTxs(
+    const { dlcTransactions, messagesList } = await this.createDlcTxs(
       dlcOffer,
       dlcAccept,
     );

--- a/packages/client/lib/Dlc.ts
+++ b/packages/client/lib/Dlc.ts
@@ -11,6 +11,7 @@ import {
   CreateCetResponse,
   CreateDlcTransactionsRequest,
   CreateDlcTransactionsResponse,
+  CreateDlcTxsResponse,
   CreateFundTransactionRequest,
   CreateFundTransactionResponse,
   CreateRefundTransactionRequest,
@@ -61,6 +62,19 @@ export default class Dlc {
    */
   async isOfferer(dlcOffer: DlcOffer, dlcAccept: DlcAccept): Promise<boolean> {
     return this.client.getMethod('isOfferer')(dlcOffer, dlcAccept);
+  }
+
+  /**
+   * Create DlcTxs object from DlcOffer and DlcAccept
+   * @param dlcOffer Dlc Offer Message
+   * @param dlcAccept Dlc Accept Message
+   * @returns {Promise<CreateDlcTxsResponse>}
+   */
+  async createDlcTxs(
+    dlcOffer: DlcOffer,
+    dlcAccept: DlcAccept,
+  ): Promise<CreateDlcTxsResponse> {
+    return this.client.getMethod('createDlcTxs')(dlcOffer, dlcAccept);
   }
 
   /**

--- a/packages/types/lib/dlc.ts
+++ b/packages/types/lib/dlc.ts
@@ -29,9 +29,20 @@ export interface DlcProvider {
    * Check whether wallet is offerer of DlcOffer or DlcAccept
    * @param dlcOffer Dlc Offer Message
    * @param dlcAccept Dlc Accept Message
-   * @returns {Promise<boolean>}
+   * @returns {Promise<CreateDlcTxsResponse>}
    */
   isOfferer(_dlcOffer: DlcOffer, _dlcAccept: DlcAccept): Promise<boolean>;
+
+  /**
+   * Create DlcTxs object from DlcOffer and DlcAccept
+   * @param dlcOffer Dlc Offer Message
+   * @param dlcAccept Dlc Accept Message
+   * @returns {Promise<boolean>}
+   */
+  createDlcTxs(
+    _dlcOffer: DlcOffer,
+    _dlcAccept: DlcAccept,
+  ): Promise<CreateDlcTxsResponse>;
 
   /**
    * Create DLC Offer Message

--- a/tests/integration/dlc/dlc.test.ts
+++ b/tests/integration/dlc/dlc.test.ts
@@ -164,6 +164,31 @@ describe('dlc provider', () => {
       );
       dlcAccept = acceptDlcOfferResponse.dlcAccept;
       dlcTransactions = acceptDlcOfferResponse.dlcTransactions;
+
+      const { dlcTransactions: dlcTxsFromMsgs } = await bob.dlc.createDlcTxs(
+        dlcOffer,
+        dlcAccept,
+      );
+
+      expect(
+        (dlcTransactions as DlcTransactionsV0).fundTx
+          .serialize()
+          .toString('hex'),
+      ).to.equal(
+        (dlcTxsFromMsgs as DlcTransactionsV0).fundTx
+          .serialize()
+          .toString('hex'),
+      );
+      expect(
+        (dlcTransactions as DlcTransactionsV0).cets[5]
+          .serialize()
+          .toString('hex'),
+      ).to.equal(
+        (dlcTxsFromMsgs as DlcTransactionsV0).cets[5]
+          .serialize()
+          .toString('hex'),
+      );
+
       console.timeEnd('accept-time');
     });
 


### PR DESCRIPTION
This PR exposes `createDlcTxs` fn which allows `dlcTxs` object to be recreated using only `DlcOffer` and `DlcAccept`