### PR TITLE
chore: use prebuilt cfd-dlc-js libs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,13 +46,6 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - run: yarn bootstrap
-
-      - name: Build cfd-dlc-js
-        if: steps.node-modules-cache.outputs.cache-hit != 'true'
-        run: npm run cmake_all
-        shell: bash
-        working-directory: ./node_modules/cfd-dlc-js
-
       - run: yarn build
       - run: yarn test
 


### PR DESCRIPTION
This PR removes npm run cmake_all for testing process as it is unnecessary with cfd-dlc-js prebuilt binaries